### PR TITLE
minijail0 cli: add --child-ld-preload

### DIFF
--- a/minijail0.1
+++ b/minijail0.1
@@ -296,6 +296,18 @@ section below for the full list of supported values for \fIprofile\fR.
 \fB--preload-library <file path>\fR
 Allows overriding the default path of \fI/lib/libminijailpreload.so\fR.  This
 is only really useful for testing.
+.TP
+\fB--child-ld-preload <library.so>\fR
+Allows setting LD_PRELOAD right before starting the target program.
+
+For dynamically linked programs, this is needed as LD_PRELOAD is used by minijail0
+to inject libminijailpreload.so. The LD_PRELOAD will apply to the target
+program, not to minijail0, nor to the program's own children, as the LD_PRELOAD
+value will be cleared by libminijailpreload.so once the program is started.
+
+For statically linked programs, this avoids having to set LD_PRELOAD before minijail0
+invocation, which might not be wanted, and applies to all the target program's children.
+.TP
 \fB--seccomp-bpf-binary <arch-specific BPF binary>\fR
 This is similar to \fB-S\fR, but
 instead of using a policy file, \fB--secomp-bpf-binary\fR expects a


### PR DESCRIPTION
When minijail0 is used with dynamically linked programs, there
is no way to set LD_PRELOAD in a way that:
1) survives until the program is execve()'s by minijail0
2) doesn't impact minijail0's own invocation

We add --child-ld-preload to this effect: LD_PRELOAD is added
to the environment right before starting the program.

Note that for now, there is still no way to get a LD_PRELOAD
to survive in the program's own environment after it is loaded,
so that his own children also get impacted.
However, if the target program is statically linked,
--child-ld-preload is still useful: it avoids having to set
LD_PRELOAD before minijail0 invocation and impacting it in an
unwanted way.

Signed-off-by: Stéphane Lesimple <speed47_github@speed47.net>