### PR TITLE
libminijail: check setup_fs_rules_fd() return value

### DIFF
--- a/libminijail.c
+++ b/libminijail.c
@@ -445,8 +445,16 @@ static int add_fs_restriction_path(struct minijail *j, const char *path,
 	 * minijail_enter(), that's this process. For minijail_run_internal(),
 	 * that's the child process.
 	 */
-	if (j->fs_rules_count == 0)
-		setup_fs_rules_fd(j);
+	if (j->fs_rules_count == 0) {
+		int ret = setup_fs_rules_fd(j);
+		if (ret && ret != ENOSYS && ret != EOPNOTSUPP) {
+			j->fs_rules_head = NULL;
+			j->fs_rules_tail = NULL;
+			free(r->path);
+			free(r);
+			return -ret;
+		}
+	}
 
 	j->fs_rules_count++;
 	return 0;
@@ -3843,7 +3851,9 @@ static int minijail_run_internal(struct minijail *j,
 	 * before logic for the child process.
 	 */
 	if (j->fs_rules_head) {
-		setup_fs_rules_fd(j);
+		int ret = setup_fs_rules_fd(j);
+		if (ret && ret != ENOSYS && ret != EOPNOTSUPP)
+			pdie("failed to create Landlock ruleset");
 		minijail_preserve_fd(j, j->fs_rules_fd, j->fs_rules_fd);
 	}
 


### PR DESCRIPTION
setup_fs_rules_fd() returns errno on failure, but both call sites discarded the return value. If it fails for reasons other than ENOSYS/EOPNOTSUPP (e.g. EMFILE when the fd table is full), fs_rules_fd stays at -1 and apply_landlock_restrictions() quietly skips landlock_restrict_self(). The process runs without Landlock.

The call site in add_fs_restriction_path() was worse: it still incremented fs_rules_count and returned 0 to the caller, so the minijail object was permanently stuck with fs_rules_fd == -1 and no way to recover.

This patch checks the return value at both sites. ENOSYS and EOPNOTSUPP are still accepted (kernel has no Landlock support), but unexpected errors like EMFILE are now surfaced: as a return code from add_fs_restriction_path(), and via pdie() in minijail_run_internal().